### PR TITLE
Update rest_command.markdown

### DIFF
--- a/source/_components/rest_command.markdown
+++ b/source/_components/rest_command.markdown
@@ -29,7 +29,7 @@ rest_command:
 
 {% configuration %}
 service_name:
-  description: The name used to expose the service. E.g., in the above example, it would be 'rest_command.service_name'.
+  description: The name used to expose the service. E.g., in the above example, it would be 'rest_command.example_request'.
   required: true
   type: map
   keys:


### PR DESCRIPTION
Fixed minor documentation error.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
